### PR TITLE
Simpler Discord messages + tolerate unknown events

### DIFF
--- a/src/lib/linear.test.ts
+++ b/src/lib/linear.test.ts
@@ -49,88 +49,174 @@ const payload = (overrides: Partial<WebhookPayload>): WebhookPayload =>
   WebhookPayloadSchema.parse({
     action: "create",
     type: "Issue",
-    createdAt: "2026-04-28T00:00:00.000Z",
     url: "https://linear.app/team/issue/ENG-1",
-    organizationId: "org-1",
-    webhookTimestamp: 1745798400000,
     data: {},
     ...overrides,
   });
 
+const ISSUE_URL = "https://linear.app/team/issue/ENG-42";
+
+describe("WebhookPayloadSchema", () => {
+  it("accepts payloads with no url (some Linear events omit it)", () => {
+    const result = WebhookPayloadSchema.safeParse({
+      action: "create",
+      type: "Reaction",
+      data: {},
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts unknown event types (Linear adds new ones over time)", () => {
+    const result = WebhookPayloadSchema.safeParse({
+      action: "create",
+      type: "AgentSession",
+      data: {},
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("formatEvent", () => {
-  it("formats Issue create with priority and assignee", () => {
-    const msg = formatEvent(
-      payload({
-        type: "Issue",
-        action: "create",
-        data: {
-          title: "Login broken",
-          number: 42,
-          team: { key: "ENG" },
-          priority: 2,
-          assignee: { name: "Alice" },
-          creator: { name: "Bob" },
-        },
-      })
-    );
-    expect(msg).toContain("New Issue Created");
-    expect(msg).toContain("ENG-42");
-    expect(msg).toContain("Login broken");
-    expect(msg).toContain("High");
-    expect(msg).toContain("Alice");
-    expect(msg).toContain("Bob");
+  it("formats Issue create as a one-liner with a link", () => {
+    expect(
+      formatEvent(
+        payload({
+          type: "Issue",
+          action: "create",
+          url: ISSUE_URL,
+          data: { title: "Login broken" },
+        })
+      )
+    ).toBe(`New issue created: [Login broken](${ISSUE_URL})`);
   });
 
-  it("falls back to Unassigned when assignee is missing", () => {
-    const msg = formatEvent(
-      payload({
-        type: "Issue",
-        action: "create",
-        data: {
-          title: "x",
-          number: 1,
-          team: { key: "ENG" },
-          priority: 4,
-          creator: { name: "Bob" },
-        },
-      })
-    );
-    expect(msg).toContain("Unassigned");
+  it("posts on state change and includes the new state", () => {
+    expect(
+      formatEvent(
+        payload({
+          type: "Issue",
+          action: "update",
+          url: ISSUE_URL,
+          data: { title: "Login broken", state: { name: "Done" } },
+          updatedFrom: { stateId: "old-state-id" },
+        })
+      )
+    ).toBe(`Issue updated: [Login broken](${ISSUE_URL}) status changed to **Done**`);
   });
 
-  it("formats Comment create with truncated body", () => {
-    const longBody = "a".repeat(250);
+  it("posts on assignee change with the new assignee", () => {
+    expect(
+      formatEvent(
+        payload({
+          type: "Issue",
+          action: "update",
+          url: ISSUE_URL,
+          data: { title: "Login broken", assignee: { name: "Alice" } },
+          updatedFrom: { assigneeId: null },
+        })
+      )
+    ).toBe(`Issue [Login broken](${ISSUE_URL}) assigned to Alice`);
+  });
+
+  it("posts on unassign", () => {
+    expect(
+      formatEvent(
+        payload({
+          type: "Issue",
+          action: "update",
+          url: ISSUE_URL,
+          data: { title: "Login broken" },
+          updatedFrom: { assigneeId: "prev-user-id" },
+        })
+      )
+    ).toBe(`Issue [Login broken](${ISSUE_URL}) unassigned`);
+  });
+
+  it("posts on title change with the previous title", () => {
+    expect(
+      formatEvent(
+        payload({
+          type: "Issue",
+          action: "update",
+          url: ISSUE_URL,
+          data: { title: "New title" },
+          updatedFrom: { title: "Old title" },
+        })
+      )
+    ).toBe(`Title updated from *Old title* to [New title](${ISSUE_URL})`);
+  });
+
+  it("skips Issue updates that don't touch state/assignee/title", () => {
+    expect(
+      formatEvent(
+        payload({
+          type: "Issue",
+          action: "update",
+          url: ISSUE_URL,
+          data: { title: "x" },
+          updatedFrom: { labelIds: ["a", "b"] },
+        })
+      )
+    ).toBeNull();
+  });
+
+  it("skips Issue updates with no updatedFrom (no-op update)", () => {
+    expect(
+      formatEvent(
+        payload({ type: "Issue", action: "update", url: ISSUE_URL, data: { title: "x" } })
+      )
+    ).toBeNull();
+  });
+
+  it("formats Comment create with author, link, and blockquote body", () => {
     const msg = formatEvent(
       payload({
         type: "Comment",
         action: "create",
-        data: { body: longBody, user: { name: "Alice" }, issue: { title: "Login broken" } },
+        url: "https://linear.app/team/issue/ENG-1#comment-1",
+        data: {
+          body: "merging now\nlooks good",
+          user: { name: "Jamie Wilkinson" },
+          issue: { title: "Login broken", url: ISSUE_URL },
+        },
       })
     );
-    expect(msg).toContain("New Comment");
-    expect(msg).toContain("Alice");
-    expect(msg).toContain("Login broken");
-    expect(msg).toContain("...");
-    expect(msg).not.toContain("a".repeat(250));
+    expect(msg).toBe(
+      `Jamie Wilkinson commented on [Login broken](${ISSUE_URL}):\n> merging now\n> looks good`
+    );
   });
 
-  it("formats Project create", () => {
+  it("truncates long comment bodies", () => {
     const msg = formatEvent(
       payload({
-        type: "Project",
+        type: "Comment",
         action: "create",
-        data: { name: "Q3 Launch", lead: { name: "Carol" }, description: "Ship it." },
+        data: {
+          body: "a".repeat(2000),
+          user: { name: "Alice" },
+          issue: { title: "x", url: ISSUE_URL },
+        },
       })
     );
-    expect(msg).toContain("Q3 Launch");
-    expect(msg).toContain("Carol");
+    expect(msg).toContain("...");
+    expect(msg).not.toContain("a".repeat(2000));
   });
 
-  it("formats ProjectUpdate with health emoji", () => {
+  it("formats Project create as a one-liner", () => {
+    const projectUrl = "https://linear.app/team/project/q3-launch";
+    expect(
+      formatEvent(
+        payload({ type: "Project", action: "create", url: projectUrl, data: { name: "Q3 Launch" } })
+      )
+    ).toBe(`New project created: [Q3 Launch](${projectUrl})`);
+  });
+
+  it("formats ProjectUpdate create with health emoji and blockquoted body", () => {
     const msg = formatEvent(
       payload({
         type: "ProjectUpdate",
         action: "create",
+        url: "https://linear.app/team/project/q3-launch",
         data: {
           project: { name: "Q3 Launch" },
           user: { name: "Carol" },
@@ -141,50 +227,19 @@ describe("formatEvent", () => {
     );
     expect(msg).toContain("🟡");
     expect(msg).toContain("Q3 Launch");
-    expect(msg).toContain("Slipping by a week.");
+    expect(msg).toContain("Carol");
+    expect(msg).toContain("> Slipping by a week.");
   });
 
-  it("formats Cycle create", () => {
+  it("formats SLA breached with the issue link", () => {
     const msg = formatEvent(
       payload({
-        type: "Cycle",
-        action: "create",
-        data: { name: "Sprint 5", number: 5, team: { name: "Engineering" } },
+        type: "IssueSLA",
+        action: "breached",
+        data: { issue: { title: "Login broken", url: ISSUE_URL } },
       })
     );
-    expect(msg).toContain("Sprint 5");
-    expect(msg).toContain("Engineering");
-  });
-
-  it("formats Document create", () => {
-    const msg = formatEvent(
-      payload({
-        type: "Document",
-        action: "create",
-        data: { title: "RFC", project: { name: "Q3 Launch" }, creator: { name: "Dave" } },
-      })
-    );
-    expect(msg).toContain("RFC");
-    expect(msg).toContain("Dave");
-  });
-
-  it("formats Initiative create", () => {
-    const msg = formatEvent(
-      payload({
-        type: "Initiative",
-        action: "create",
-        data: { name: "Reliability", description: "Reduce error rate." },
-      })
-    );
-    expect(msg).toContain("Reliability");
-  });
-
-  it("formats SLA breached with severity emoji", () => {
-    const msg = formatEvent(
-      payload({ type: "IssueSLA", action: "breached", data: { issue: { title: "Login broken" } } })
-    );
-    expect(msg).toContain("🚨");
-    expect(msg).toContain("Login broken");
+    expect(msg).toBe(`🚨 SLA breached: [Login broken](${ISSUE_URL})`);
   });
 
   it("formats OAuthAppRevoked", () => {
@@ -198,19 +253,17 @@ describe("formatEvent", () => {
 
   it("returns null for IssueAttachment events (too noisy)", () => {
     expect(
-      formatEvent(
-        payload({
-          type: "IssueAttachment",
-          action: "create",
-          data: { title: "screenshot.png", issue: { title: "x" }, creator: { name: "Alice" } },
-        })
-      )
+      formatEvent(payload({ type: "IssueAttachment", action: "create", data: {} }))
     ).toBeNull();
   });
 
-  it("returns null for an unsupported action on a known type", () => {
+  it("returns null for unknown event types instead of crashing", () => {
+    expect(formatEvent(payload({ type: "AgentSession", action: "create", data: {} }))).toBeNull();
+  });
+
+  it("returns null for Project:update (too generic to be useful)", () => {
     expect(
-      formatEvent(payload({ type: "Issue", action: "remove", data: { number: 1 } }))
+      formatEvent(payload({ type: "Project", action: "update", data: { name: "x" } }))
     ).toBeNull();
   });
 });

--- a/src/lib/linear.ts
+++ b/src/lib/linear.ts
@@ -15,31 +15,14 @@ export const env = (): z.infer<typeof envSchema> => {
   return cachedEnv;
 };
 
+// Lenient on purpose: Linear adds new event types over time, and some events
+// (Reaction, OAuthAppRevoked, etc.) omit fields like `url`. We accept anything
+// shaped roughly like a Linear webhook and let formatEvent decide.
 export const WebhookPayloadSchema = z.object({
-  action: z.enum(["create", "update", "remove", "set", "highRisk", "breached"]),
-  type: z.enum([
-    "Issue",
-    "Comment",
-    "Project",
-    "ProjectUpdate",
-    "IssueAttachment",
-    "IssueLabel",
-    "Reaction",
-    "Document",
-    "Initiative",
-    "InitiativeUpdate",
-    "Cycle",
-    "Customer",
-    "CustomerRequest",
-    "User",
-    "IssueSLA",
-    "OAuthAppRevoked",
-  ]),
-  createdAt: z.string(),
-  data: z.record(z.string(), z.unknown()),
-  url: z.string(),
-  organizationId: z.string(),
-  webhookTimestamp: z.number(),
+  action: z.string(),
+  type: z.string(),
+  data: z.record(z.string(), z.unknown()).optional(),
+  url: z.string().optional(),
   updatedFrom: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -59,13 +42,14 @@ export const verifyLinearSignature = (
 
 const truncate = (s: string, n = 200) => (s.length <= n ? s : `${s.slice(0, n)}...`);
 
-const PRIORITY_NAME: Record<number, string> = {
-  0: "No priority",
-  1: "Urgent",
-  2: "High",
-  3: "Medium",
-  4: "Low",
-};
+const link = (text: string | undefined, url: string | undefined) =>
+  text && url ? `[${text}](${url})` : (text ?? "");
+
+const blockquote = (s: string) =>
+  s
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
 
 const HEALTH_EMOJI: Record<string, string> = {
   onTrack: "🟢",
@@ -75,97 +59,76 @@ const HEALTH_EMOJI: Record<string, string> = {
 };
 
 // Returns the Discord message string, or null if the event should be skipped.
-// Skipped: Reaction, IssueAttachment, IssueLabel (too noisy), and any unknown type/action combo.
+// Skipped: noisy events (Reaction, IssueAttachment, IssueLabel, label-only updates),
+// Issue updates that don't change state/assignee/title, and any unknown type/action.
 export function formatEvent(p: WebhookPayload): string | null {
-  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous payload shape, validated by Zod above.
-  const d = p.data as any;
-  const key = `${p.type}:${p.action}`;
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous payload shape, validated as a webhook above.
+  const d = (p.data ?? {}) as any;
+  const url = p.url;
 
-  switch (key) {
-    case "Issue:create": {
-      const id = `${d.team?.key}-${d.number ?? 0}`;
-      return [
-        `🆕 **New Issue Created**`,
-        `**${id}**: ${d.title}`,
-        `**Priority**: ${PRIORITY_NAME[d.priority] ?? "Unknown"}`,
-        `**Assignee**: ${d.assignee?.name ?? "Unassigned"}`,
-        `**Creator**: ${d.creator?.name}`,
-      ].join("\n");
-    }
+  switch (`${p.type}:${p.action}`) {
+    case "Issue:create":
+      return `New issue created: ${link(d.title, url)}`;
+
     case "Issue:update": {
-      const id = `${d.team?.key}-${d.number ?? 0}`;
-      return [
-        `📝 **Issue Updated**`,
-        `**${id}**: ${d.title}`,
-        `**Status**: ${d.state?.name}`,
-        `**Assignee**: ${d.assignee?.name ?? "Unassigned"}`,
-      ].join("\n");
+      const changed = p.updatedFrom ?? {};
+      if ("stateId" in changed) {
+        return `Issue updated: ${link(d.title, url)} status changed to **${d.state?.name}**`;
+      }
+      if ("assigneeId" in changed) {
+        return d.assignee?.name
+          ? `Issue ${link(d.title, url)} assigned to ${d.assignee.name}`
+          : `Issue ${link(d.title, url)} unassigned`;
+      }
+      if ("title" in changed) {
+        return `Title updated from *${changed.title}* to ${link(d.title, url)}`;
+      }
+      return null;
     }
 
-    case "Comment:create":
-      return [
-        `💬 **New Comment**`,
-        `**Issue**: ${d.issue?.title}`,
-        `**Author**: ${d.user?.name}`,
-        `**Comment**: ${truncate(d.body ?? "")}`,
-      ].join("\n");
-
-    case "Project:create": {
-      const lines = [`📊 **New Project Created:** ${d.name}`];
-      if (d.lead?.name) lines.push(`**Lead:** ${d.lead.name}`);
-      if (d.description) lines.push(`**Description:** ${truncate(d.description, 100)}`);
-      return lines.join("\n");
+    case "Comment:create": {
+      const issueUrl = d.issue?.url ?? url;
+      const body = blockquote(truncate(d.body ?? "", 1000));
+      return `${d.user?.name} commented on ${link(d.issue?.title, issueUrl)}:\n${body}`;
     }
-    case "Project:update":
-      return `📊 **Project Updated:** ${d.name}`;
+
+    case "Project:create":
+      return `New project created: ${link(d.name, url)}`;
 
     case "ProjectUpdate:create": {
-      const emoji = HEALTH_EMOJI[d.health] ?? "⚪";
-      const lines = [
-        `${emoji} **Project Update:** ${d.project?.name}`,
-        `**Author:** ${d.user?.name}`,
-        `**Status:** ${d.health}`,
-      ];
-      if (d.body) lines.push(`**Update:** ${truncate(d.body.replace(/\n/g, " ").trim())}`);
-      return lines.join("\n");
-    }
-    case "ProjectUpdate:update": {
-      const emoji = HEALTH_EMOJI[d.health] ?? "⚪";
-      return `${emoji} **Project Update Modified:** ${d.project?.name} by ${d.user?.name}`;
+      const emoji = HEALTH_EMOJI[d.health];
+      const head = `${emoji ? `${emoji} ` : ""}Project update on ${link(d.project?.name, url)} by ${d.user?.name}`;
+      return d.body ? `${head}:\n${blockquote(truncate(d.body, 500))}` : head;
     }
 
     case "Cycle:create":
-      return `🔄 **New Cycle Created:** ${d.team?.name} - ${d.name} (${d.number})`;
-    case "Cycle:update":
-      return `🔄 **Cycle Updated:** ${d.team?.name} - ${d.name}`;
+      return `New cycle: ${d.team?.name} ${link(d.name, url)}`;
 
     case "Document:create":
-      return `📄 **New Document:** ${d.title}\n**Project:** ${d.project?.name ?? "None"}\n**Creator:** ${d.creator?.name}`;
+      return `New document: ${link(d.title, url)}`;
 
     case "Initiative:create":
-      return `🎯 **New Initiative:** ${d.name}${d.description ? `\n${truncate(d.description, 100)}` : ""}`;
+      return `New initiative: ${link(d.name, url)}`;
 
     case "InitiativeUpdate:create":
-      return `🎯 **Initiative Update:** ${d.initiative?.name}\n**Author:** ${d.user?.name}${d.body ? `\n${truncate(d.body)}` : ""}`;
+      return `Initiative update on ${d.initiative?.name} by ${d.user?.name}`;
 
     case "Customer:create":
-      return `👤 **New Customer:** ${d.name} (${d.email})`;
+      return `New customer: ${d.name}${d.email ? ` (${d.email})` : ""}`;
 
     case "CustomerRequest:create":
-      return `📮 **Customer Request:** ${d.title || d.issue?.title}\n**Customer:** ${d.customer?.name}\n**Issue:** ${d.issue?.title}`;
+      return `New customer request: ${d.title || d.issue?.title} (from ${d.customer?.name})`;
 
     case "User:create":
-      return `👋 **New Team Member:** ${d.name} joined the workspace`;
+      return `New team member: ${d.name} joined`;
 
-    case "IssueSLA:set":
-      return `⏰ **SLA Set:** ${d.issue?.title}\n**Breaches at:** ${d.breachesAt}`;
     case "IssueSLA:highRisk":
-      return `⚠️ **SLA High Risk:** ${d.issue?.title} is at risk of breaching SLA`;
+      return `⚠️ SLA at risk: ${link(d.issue?.title, d.issue?.url)}`;
     case "IssueSLA:breached":
-      return `🚨 **SLA BREACHED:** ${d.issue?.title} has breached its SLA`;
+      return `🚨 SLA breached: ${link(d.issue?.title, d.issue?.url)}`;
 
     case "OAuthAppRevoked:remove":
-      return `🔐 **OAuth App Access Revoked** - Please check your Linear integration settings`;
+      return `🔐 OAuth app access revoked — check Linear integration settings`;
 
     default:
       return null;

--- a/src/pages/api/webhook.ts
+++ b/src/pages/api/webhook.ts
@@ -19,37 +19,43 @@ const readRawBody = (req: NextApiRequest): Promise<Buffer> =>
     req.on("error", reject);
   });
 
+const headerValue = (h: string | string[] | undefined): string | undefined =>
+  Array.isArray(h) ? h[0] : h;
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const delivery = headerValue(req.headers["linear-delivery"]);
+
   try {
     const rawBody = await readRawBody(req);
 
     if (
       !verifyLinearSignature(rawBody, req.headers["linear-signature"], env().LINEAR_WEBHOOK_SECRET)
     ) {
-      console.warn("Rejected webhook: signature mismatch");
+      console.warn("Rejected webhook: signature mismatch", { delivery });
       return res.status(401).json({ ok: false, error: "Invalid signature" });
     }
 
     const parsed = WebhookPayloadSchema.safeParse(JSON.parse(rawBody.toString("utf8")));
     if (!parsed.success) {
-      console.error("Invalid webhook payload:", parsed.error);
+      console.error("Invalid webhook payload:", { delivery, error: parsed.error });
       return res.status(400).json({ ok: false, error: "Invalid payload" });
     }
 
     const payload = parsed.data;
+    const ctx = { delivery, type: payload.type, action: payload.action, url: payload.url };
     const message = formatEvent(payload);
 
     if (!message) {
-      console.log("Skipped:", { type: payload.type, action: payload.action });
+      console.log("Skipped:", ctx);
       return res.json({ ok: true, skipped: true });
     }
 
-    console.log("Posting:", { type: payload.type, action: payload.action });
+    console.log("Posting:", ctx);
     await sendToDiscord(message, isProjectEvent(payload));
 
     return res.json({ ok: true });
   } catch (error) {
-    console.error("Webhook error:", error);
+    console.error("Webhook error:", { delivery, error });
     return res.status(500).json({ ok: false, error: "Server error" });
   }
 }


### PR DESCRIPTION
Match the old simple message style and stop 400ing on event types we don't handle.

## Discord format (before → after)

Issue create:
```
🆕 **New Issue Created**
**ENG-42**: Login broken
**Priority**: High
**Assignee**: Alice
**Creator**: Bob
```
becomes
```
New issue created: [Login broken](https://linear.app/...)
```

Issue update (only fires on meaningful changes now):
```
📝 **Issue Updated**
**ENG-42**: Login broken
**Status**: Done
**Assignee**: Alice
```
becomes
```
Issue updated: [Login broken](https://linear.app/...) status changed to **Done**
```

Comment:
```
💬 **New Comment**
**Issue**: Login broken
**Author**: Jamie Wilkinson
**Comment**: merging now
```
becomes
```
Jamie Wilkinson commented on [Login broken](https://linear.app/...):
> merging now
> looks good
```

## Other fixes

- Linear sends event types we don't handle (e.g. `AgentSession`) and sometimes omits `url`. We were 400ing on these. Now lenient: unknown types return null and skip.
- `Issue:update` only fires when state/assignee/title actually changed (uses `updatedFrom`). Label/priority/description-only updates are silent. Matches the old behavior.
- Webhook handler now logs the `linear-delivery` header alongside type/action so you can correlate Vercel logs with Linear's webhook log.

## Tests
26 passing (up from 20). Covers update-filter logic, lenient schema, and link formatting.