### PR TITLE
Render project updates as rich Discord embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The whole thing is one API route plus one library file (~250 lines of TypeScript
 
 1. Linear POSTs to `/api/webhook` whenever an event happens (issue created, comment posted, etc.)
 2. The handler verifies Linear's HMAC-SHA256 signature against the raw body
-3. The event is formatted into a one-liner like `New issue created: [Login broken](https://linear.app/…)`
+3. The event is formatted into a one-liner like `New issue created: [Login broken](https://linear.app/…)`; project updates use rich embeds with linked titles and health-colored bars
 4. The message is forwarded to your Discord webhook
 
 Unknown event types and noisy ones (reactions, label-only updates, attachments) are silently skipped. `Issue:update` only fires on state, assignee, or title changes.

--- a/src/lib/linear.test.ts
+++ b/src/lib/linear.test.ts
@@ -59,6 +59,13 @@ const payload = (overrides: Partial<WebhookPayload>): WebhookPayload =>
 
 const ISSUE_URL = "https://linear.app/team/issue/ENG-42";
 
+const projectUpdateEmbed = (message: ReturnType<typeof formatEvent>) => {
+  assert(message !== null && typeof message !== "string");
+  const embed = message.embeds[0];
+  assert(embed);
+  return embed;
+};
+
 describe("WebhookPayloadSchema", () => {
   it("accepts payloads with no url (some Linear events omit it)", () => {
     const result = WebhookPayloadSchema.safeParse({
@@ -240,24 +247,51 @@ describe("formatEvent", () => {
     ).toBe(`New project created: [Q3 Launch](${projectUrl})`);
   });
 
-  it("formats ProjectUpdate create with health emoji and blockquoted body", () => {
+  it("formats ProjectUpdate create as a linked, health-colored embed", () => {
     const msg = formatEvent(
       payload({
         type: "ProjectUpdate",
         action: "create",
-        url: "https://linear.app/team/project/q3-launch",
+        url: "https://linear.app/team/project/q3-launch/update/123",
         data: {
           project: { name: "Q3 Launch" },
           user: { name: "Carol" },
           health: "atRisk",
           body: "Slipping by a week.",
+          createdAt: "2026-08-12T12:34:56.000Z",
         },
       })
     );
-    expect(msg).toContain("🟡");
-    expect(msg).toContain("Q3 Launch");
-    expect(msg).toContain("Carol");
-    expect(msg).toContain("> Slipping by a week.");
+    expect(projectUpdateEmbed(msg)).toEqual({
+      title: "Q3 Launch",
+      url: "https://linear.app/team/project/q3-launch/update/123",
+      description: "Slipping by a week.",
+      color: 0xfee75c,
+      author: { name: "Carol" },
+      footer: { text: "At risk" },
+      timestamp: "2026-08-12T12:34:56.000Z",
+    });
+  });
+
+  it("normalizes Linear's angle-wrapped links for Discord embed markdown", () => {
+    const notionUrl = "https://app.notion.com/p/glifxyz/Sindy-De-Vries-123";
+    const githubUrl = "https://github.com/glifxyz/marketing";
+    const msg = formatEvent(
+      payload({
+        type: "ProjectUpdate",
+        action: "create",
+        data: {
+          project: { name: "Outbound" },
+          user: { name: "Lamia" },
+          health: "onTrack",
+          body: `Sindy: [${notionUrl}](<${notionUrl}>)\n[Marketing repo](<${githubUrl}>)`,
+        },
+      })
+    );
+
+    expect(projectUpdateEmbed(msg).description).toBe(
+      `Sindy: [app.notion.com/…](${notionUrl})\n[Marketing repo](${githubUrl})`
+    );
   });
 
   // Regression: a blind slice used to sever links mid-URL, e.g.
@@ -272,13 +306,13 @@ describe("formatEvent", () => {
           project: { name: "Q3 Launch" },
           user: { name: "Carol" },
           health: "onTrack",
-          body: `${"a".repeat(1480)} ${link} trailing text`,
+          body: `${"a".repeat(3980)} ${link} trailing text`,
         },
       })
     );
-    assert(msg !== null);
+    const description = projectUpdateEmbed(msg).description ?? "";
     // Either the link survives whole or it's dropped whole — never a fragment.
-    expect(msg.includes("[MCP Public Launch]")).toBe(msg.includes(link));
+    expect(description.includes("[MCP Public Launch]")).toBe(description.includes(link));
   });
 
   it("keeps a bare URL intact when truncating", () => {
@@ -294,12 +328,12 @@ describe("formatEvent", () => {
         },
       })
     );
-    assert(msg !== null);
+    assert(typeof msg === "string");
     expect(msg.includes("https://github.com")).toBe(msg.includes(url));
   });
 
   it("keeps long project update bodies that fit under the limit whole", () => {
-    const body = `${"word ".repeat(200)}[link](https://linear.app/x)`;
+    const body = `${"word ".repeat(700)}[link](https://linear.app/x)`;
     const msg = formatEvent(
       payload({
         type: "ProjectUpdate",
@@ -312,9 +346,9 @@ describe("formatEvent", () => {
         },
       })
     );
-    assert(msg !== null);
-    expect(msg).toContain("[link](https://linear.app/x)");
-    expect(msg).not.toContain("...");
+    const description = projectUpdateEmbed(msg).description ?? "";
+    expect(description).toContain("[link](https://linear.app/x)");
+    expect(description).not.toContain("...");
   });
 
   it("formats SLA breached with the issue link", () => {
@@ -356,14 +390,16 @@ describe("formatEvent", () => {
 
 describe("sendToDiscord", () => {
   // A real local server rather than a fetch mock, so we exercise the actual POSTs.
-  const received: Array<{ path: string; content: string }> = [];
+  const received: Array<{ path: string; content?: string; embeds?: unknown[] }> = [];
   const server = createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on("data", (c) => chunks.push(Buffer.from(c)));
     req.on("end", () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString());
       received.push({
         path: req.url ?? "",
-        content: JSON.parse(Buffer.concat(chunks).toString()).content,
+        ...(body.content !== undefined ? { content: body.content } : {}),
+        ...(body.embeds !== undefined ? { embeds: body.embeds } : {}),
       });
       res.writeHead(204).end();
     });
@@ -388,15 +424,17 @@ describe("sendToDiscord", () => {
 
   it("posts project events to both webhooks", async () => {
     received.length = 0;
-    await sendToDiscord("a project update", true);
+    const embeds = [{ title: "Q3 Launch", description: "A [link](https://example.com)" }];
+    await sendToDiscord({ embeds }, true);
     expect(received.map((r) => r.path).sort()).toEqual(["/main", "/projects"]);
-    expect(received.every((r) => r.content === "a project update")).toBe(true);
+    expect(received.every((r) => JSON.stringify(r.embeds) === JSON.stringify(embeds))).toBe(true);
   });
 
   it("clamps content to Discord's message limit", async () => {
     received.length = 0;
     await sendToDiscord("x".repeat(3000));
-    assert(received[0]);
-    expect(received[0].content.length).toBeLessThanOrEqual(2000);
+    const content = received[0]?.content;
+    assert(content);
+    expect(content.length).toBeLessThanOrEqual(2000);
   });
 });

--- a/src/lib/linear.ts
+++ b/src/lib/linear.ts
@@ -64,17 +64,51 @@ const blockquote = (s: string) =>
     .map((line) => `> ${line}`)
     .join("\n");
 
-const HEALTH_EMOJI: Record<string, string> = {
-  onTrack: "🟢",
-  atRisk: "🟡",
-  offTrack: "🔴",
-  completed: "✅",
+const PROJECT_HEALTH: Record<string, { color: number; label: string }> = {
+  onTrack: { color: 0x57f287, label: "On track" },
+  atRisk: { color: 0xfee75c, label: "At risk" },
+  offTrack: { color: 0xed4245, label: "Off track" },
+  completed: { color: 0x5865f2, label: "Completed" },
 };
 
-// Returns the Discord message string, or null if the event should be skipped.
+const ANGLE_WRAPPED_MARKDOWN_LINK = /\[([^\]\n]+)\]\(<(https?:\/\/[^>\n]+)>\)/g;
+
+// Linear represents auto-linked URLs as [https://example.com/path](<https://example.com/path>).
+// Discord does not reliably parse that form, even inside embeds. Remove the angle brackets and
+// replace noisy raw-URL labels with a compact human-readable label.
+const normalizeDiscordLinks = (markdown: string): string =>
+  markdown.replace(ANGLE_WRAPPED_MARKDOWN_LINK, (_match, label: string, target: string) => {
+    let display = label;
+    if (label === target) {
+      try {
+        const parsed = new URL(target);
+        const hostname = parsed.hostname.replace(/^www\./, "");
+        const hasPath =
+          parsed.pathname !== "/" || parsed.search.length > 0 || parsed.hash.length > 0;
+        display = `${hostname}${hasPath ? "/…" : ""}`;
+      } catch {
+        // The regex only accepts HTTP(S), but keep the original label if URL parsing ever fails.
+      }
+    }
+    return `[${display}](${target})`;
+  });
+
+export type DiscordEmbed = {
+  title: string;
+  url?: string;
+  description?: string;
+  color?: number;
+  author?: { name: string };
+  footer?: { text: string };
+  timestamp?: string;
+};
+
+export type DiscordMessage = string | { embeds: DiscordEmbed[] };
+
+// Returns the Discord message payload, or null if the event should be skipped.
 // Skipped: noisy events (Reaction, IssueAttachment, IssueLabel, label-only updates),
 // Issue updates that don't change state/assignee/title, and any unknown type/action.
-export function formatEvent(p: WebhookPayload): string | null {
+export function formatEvent(p: WebhookPayload): DiscordMessage | null {
   // biome-ignore lint/suspicious/noExplicitAny: heterogeneous payload shape, validated as a webhook above.
   const d = (p.data ?? {}) as any;
   const url = p.url;
@@ -109,9 +143,20 @@ export function formatEvent(p: WebhookPayload): string | null {
       return `New project created: ${link(d.name, url)}`;
 
     case "ProjectUpdate:create": {
-      const emoji = HEALTH_EMOJI[d.health];
-      const head = `${emoji ? `${emoji} ` : ""}Project update on ${link(d.project?.name, url)} by ${d.user?.name}`;
-      return d.body ? `${head}:\n${blockquote(truncate(d.body, 1500))}` : head;
+      const health = PROJECT_HEALTH[d.health];
+      const timestamp =
+        typeof d.createdAt === "string" && !Number.isNaN(Date.parse(d.createdAt))
+          ? new Date(d.createdAt).toISOString()
+          : undefined;
+      const embed: DiscordEmbed = {
+        title: truncate(d.project?.name ?? "Project update", 256),
+        ...(url ? { url } : {}),
+        ...(d.body ? { description: truncate(normalizeDiscordLinks(d.body), 4000) } : {}),
+        ...(health ? { color: health.color, footer: { text: health.label } } : {}),
+        ...(d.user?.name ? { author: { name: truncate(d.user.name, 256) } } : {}),
+        ...(timestamp ? { timestamp } : {}),
+      };
+      return { embeds: [embed] };
     }
 
     case "Cycle:create":
@@ -153,11 +198,15 @@ export const isProjectEvent = (p: WebhookPayload): boolean =>
 
 // Project events go to the main channel *and* the projects channel, so they keep
 // their place in the normal feed while also getting extra visibility.
-export const sendToDiscord = async (message: string, alsoProjects = false): Promise<void> => {
+export const sendToDiscord = async (
+  message: DiscordMessage,
+  alsoProjects = false
+): Promise<void> => {
   const e = env();
-  // Discord rejects content over 2000 chars; leave room for the ellipsis.
-  const content = truncate(message, 1990);
+  // Discord rejects content over 2000 chars; leave room for the ellipsis. Rich embeds are already
+  // clamped to their field limits by formatEvent.
+  const payload = typeof message === "string" ? { content: truncate(message, 1990) } : message;
   const urls = [e.DISCORD_WEBHOOK];
   if (alsoProjects && e.DISCORD_WEBHOOK_PROJECTS) urls.push(e.DISCORD_WEBHOOK_PROJECTS);
-  await Promise.all(urls.map((url) => wretch(url).post({ content }).res()));
+  await Promise.all(urls.map((url) => wretch(url).post(payload).res()));
 };

--- a/src/pages/api/webhook.ts
+++ b/src/pages/api/webhook.ts
@@ -51,7 +51,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const projects = isProjectEvent(payload);
-    console.log("Posting:", { ...ctx, projects, length: message.length, message });
+    const length = typeof message === "string" ? message.length : JSON.stringify(message).length;
+    console.log("Posting:", { ...ctx, projects, length, message });
     await sendToDiscord(message, projects);
 
     return res.json({ ok: true });


### PR DESCRIPTION
## What changed

- render Linear project updates as Discord rich embeds instead of blockquoted message content
- link the project title, show the update author and timestamp, and color the embed by project health
- normalize Linear's angle-wrapped markdown links and shorten raw-URL labels to readable domain labels
- preserve plain-content delivery for every other event type and rich embeds across both configured project webhooks

## Why

Linear auto-links arrive in project update bodies as `[raw URL](<raw URL>)`. Discord parses that form unreliably inside multiline blockquotes, leaving links unclickable. Embed descriptions support markdown links reliably, and normalization removes the angle-wrapped target that triggers the issue.

## Impact

Project update links are clickable and notifications are easier to scan. Other Linear notification formats are unchanged.

## Validation

- 34 Vitest tests
- TypeScript typecheck
- Biome check
- Next.js production build

Linear: https://linear.app/glif/issue/STAFF-234/linear-to-discord-markdown-links-in-project-update-blockquotes-dont